### PR TITLE
Add support for SSH Host Key Checking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,11 +65,15 @@ jobs:
             Subsystem sftp /usr/lib/openssh/sftp-server
           EOF
           sudo systemctl restart sshd
+          echo 'SSH_KNOWN_HOSTS<<EOF' >> $GITHUB_ENV
+          echo $(ssh-keyscan localhost) >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
       - name: With everything
         uses: ./
         with:
           playbook: playbook.yml
           key: ${{env.SSH_PRIVATE_KEY}}
+          known_hosts: ${{env.SSH_KNOWN_HOSTS}}
           directory: test
           vault_password: test
           requirements: requirements.yml

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,9 @@ inputs:
   vault_password:
     description: The password used for decrypting vaulted files
     required: false
+  known_hosts:
+    description: Contents of SSH known_hosts file
+    required: false
   options:
     description: Extra options that should be passed to ansible-playbook command
     required: false

--- a/post.js
+++ b/post.js
@@ -14,6 +14,7 @@ async function main() {
         const keyFile = core.getState("keyFile")
         const inventoryFile = core.getState("inventoryFile")
         const vaultPasswordFile = core.getState("vaultPasswordFile")
+        const knownHostsFile = core.getState("knownHostsFile")
 
         if (directory)
             process.chdir(directory)
@@ -26,6 +27,10 @@ async function main() {
 
         if (vaultPasswordFile)
             rm(vaultPasswordFile)
+
+        if (knownHostsFile)
+            rm(knownHostsFile)
+
     } catch (error) {
         core.setFailed(error.message)
     }


### PR DESCRIPTION
By default it seems that SSH host key checking has been disabled. This
patch makes it optional. If a variable named known_hosts is passed in,
the key checking will be enabled. The variable should contain the
complete contents of the known_hosts file, which must contain the public
key(s) of the host(s) in the inventory.