### PR TITLE
Capture output of stdout and stderr to Actions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,10 +32,8 @@ inputs:
     description: Set to "true" if root is required for running your playbook
     required: false
 outputs:
-  stdout:
-    description: The captured output of stdout from the Ansible Playbook run
-  stderr:
-    description: The captured output of stderr from the Ansible Playbook run
+  output:
+    description: The captured output of both stdout and stderr from the Ansible Playbook run
 runs:
   using: node12
   main: main.js

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,11 @@ inputs:
   sudo:
     description: Set to "true" if root is required for running your playbook
     required: false
+outputs:
+  stdout:
+    description: The captured output of stdout from the Ansible Playbook run
+  stderr:
+    description: The captured output of stderr from the Ansible Playbook run
 runs:
   using: node12
   main: main.js

--- a/main.js
+++ b/main.js
@@ -16,10 +16,10 @@ async function main() {
         const options = core.getInput("options")
         const sudo    = core.getInput("sudo")
 
-        let cmd = ["ansible-playbook", playbook]
+        let args = ["ansible-playbook", playbook]
 
         if (options) {
-            cmd.push(options.replace(/\n/g, " "))
+            args.push(options.replace(/\n/g, " "))
         }
 
         if (directory) {
@@ -45,38 +45,38 @@ async function main() {
             const keyFile = ".ansible_key"
             fs.writeFileSync(keyFile, key + os.EOL, { mode: 0600 })
             core.saveState("keyFile", keyFile)
-            cmd.push("--key-file")
-            cmd.push(keyFile)
+            args.push("--key-file")
+            args.push(keyFile)
         }
 
         if (inventory) {
             const inventoryFile = ".ansible_inventory"
             fs.writeFileSync(inventoryFile, inventory, { mode: 0600 })
             core.saveState("inventoryFile", inventoryFile)
-            cmd.push("--inventory-file")
-            cmd.push(inventoryFile)
+            args.push("--inventory-file")
+            args.push(inventoryFile)
         }
 
         if (vaultPassword) {
             const vaultPasswordFile = ".ansible_vault_password"
             fs.writeFileSync(vaultPasswordFile, vaultPassword, { mode: 0600 })
             core.saveState("vaultPasswordFile", vaultPasswordFile)
-            cmd.push("--vault-password-file")
-            cmd.push(vaultPasswordFile)
+            args.push("--vault-password-file")
+            args.push(vaultPasswordFile)
         }
 
         if (knownHosts) {
             const knownHostsFile = ".ansible_known_hosts"
             fs.writeFileSync(knownHostsFile, knownHosts, { mode: 0600 })
             core.saveState("knownHostsFile", knownHostsFile)
-            cmd.push(`--ssh-common-args="-o UserKnownHostsFile=${knownHostsFile}"`)
+            args.push(`--ssh-common-args="-o UserKnownHostsFile=${knownHostsFile}"`)
             process.env.ANSIBLE_HOST_KEY_CHECKING = "True"
         } else {
             process.env.ANSIBLE_HOST_KEY_CHECKING = "False"
         }
 
         if (sudo) {
-            cmd.unshift("sudo", "-E", "env", `PATH=${process.env.PATH}`)
+            args.unshift("sudo", "-E", "env", `PATH=${process.env.PATH}`)
         }
 
         process.env.ANSIBLE_FORCE_COLOR = "True"
@@ -91,7 +91,7 @@ async function main() {
           }
         }
 
-        await exec.exec(cmd.join(' '), execOptions)
+        await exec.exec(args.join(' '), execOptions)
     } catch (error) {
         core.setFailed(error.message)
     }

--- a/main.js
+++ b/main.js
@@ -81,7 +81,17 @@ async function main() {
 
         process.env.ANSIBLE_FORCE_COLOR = "True"
 
-        await exec.exec(cmd.join(' '))
+        const execOptions = {};
+        execOptions.listeners = {
+          stdout: (data: Buffer) => {
+            core.setOutput('stdout', data.toString());
+          },
+          stderr: (data: Buffer) => {
+            core.setOutput('stderr', data.toString());
+          }
+        };
+
+        await exec.exec(cmd.join(' '), execOptions)
     } catch (error) {
         core.setFailed(error.message)
     }

--- a/main.js
+++ b/main.js
@@ -16,10 +16,10 @@ async function main() {
         const options = core.getInput("options")
         const sudo    = core.getInput("sudo")
 
-        let args = [playbook]
+        let cmd = [playbook]
 
         if (options) {
-            args.push(options.replace(/\n/g, " "))
+            cmd.push(options.replace(/\n/g, " "))
         }
 
         if (directory) {
@@ -45,38 +45,38 @@ async function main() {
             const keyFile = ".ansible_key"
             fs.writeFileSync(keyFile, key + os.EOL, { mode: 0600 })
             core.saveState("keyFile", keyFile)
-            args.push("--key-file")
-            args.push(keyFile)
+            cmd.push("--key-file")
+            cmd.push(keyFile)
         }
 
         if (inventory) {
             const inventoryFile = ".ansible_inventory"
             fs.writeFileSync(inventoryFile, inventory, { mode: 0600 })
             core.saveState("inventoryFile", inventoryFile)
-            args.push("--inventory-file")
-            args.push(inventoryFile)
+            cmd.push("--inventory-file")
+            cmd.push(inventoryFile)
         }
 
         if (vaultPassword) {
             const vaultPasswordFile = ".ansible_vault_password"
             fs.writeFileSync(vaultPasswordFile, vaultPassword, { mode: 0600 })
             core.saveState("vaultPasswordFile", vaultPasswordFile)
-            args.push("--vault-password-file")
-            args.push(vaultPasswordFile)
+            cmd.push("--vault-password-file")
+            cmd.push(vaultPasswordFile)
         }
 
         if (knownHosts) {
             const knownHostsFile = ".ansible_known_hosts"
             fs.writeFileSync(knownHostsFile, knownHosts, { mode: 0600 })
             core.saveState("knownHostsFile", knownHostsFile)
-            args.push(`--ssh-common-args="-o UserKnownHostsFile=${knownHostsFile}"`)
+            cmd.push(`--ssh-common-args="-o UserKnownHostsFile=${knownHostsFile}"`)
             process.env.ANSIBLE_HOST_KEY_CHECKING = "True"
         } else {
             process.env.ANSIBLE_HOST_KEY_CHECKING = "False"
         }
 
         if (sudo) {
-            args.unshift("sudo", "-E", "env", `PATH=${process.env.PATH}`)
+            cmd.unshift("sudo", "-E", "env", `PATH=${process.env.PATH}`)
         }
 
         process.env.ANSIBLE_FORCE_COLOR = "True"
@@ -91,7 +91,7 @@ async function main() {
           }
         }
 
-        await exec.exec("ansible-playbook", args, execOptions)
+        await exec.exec("ansible-playbook", cmd, execOptions)
     } catch (error) {
         core.setFailed(error.message)
     }

--- a/main.js
+++ b/main.js
@@ -81,21 +81,19 @@ async function main() {
 
         process.env.ANSIBLE_FORCE_COLOR = "True"
 
-        let stdout = ''
-        let stderr = ''
+        let output = ''
         const execOptions = {}
         execOptions.listeners = {
           stdout: function(data) {
-            stdout += data.toString()
+            output += data.toString()
           },
           stderr: function(data) {
-            stderr += data.toString()
+            output += data.toString()
           }
         }
 
         await exec.exec("ansible-playbook", cmd, execOptions)
-        core.setOutput('stdout', stdout)
-        core.setOutput('stderr', stderr)
+        core.setOutput('output', output)
     } catch (error) {
         core.setFailed(error.message)
     }

--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ async function main() {
         const options = core.getInput("options")
         const sudo    = core.getInput("sudo")
 
-        let args = ["ansible-playbook", playbook]
+        let args = [playbook]
 
         if (options) {
             args.push(options.replace(/\n/g, " "))
@@ -91,7 +91,7 @@ async function main() {
           }
         }
 
-        await exec.exec(args.join(' '), execOptions)
+        await exec.exec("ansible-playbook", args, execOptions)
     } catch (error) {
         core.setFailed(error.message)
     }

--- a/main.js
+++ b/main.js
@@ -81,7 +81,7 @@ async function main() {
 
         process.env.ANSIBLE_FORCE_COLOR = "True"
 
-        const execOptions = {};
+        const execOptions = {}
         execOptions.listeners = {
           stdout: function(data) {
             core.setOutput('stdout', data.toString());
@@ -89,7 +89,7 @@ async function main() {
           stderr: function(data) {
             core.setOutput('stderr', data.toString());
           }
-        };
+        }
 
         await exec.exec(cmd.join(' '), execOptions)
     } catch (error) {

--- a/main.js
+++ b/main.js
@@ -81,17 +81,21 @@ async function main() {
 
         process.env.ANSIBLE_FORCE_COLOR = "True"
 
+        let stdout = ''
+        let stderr = ''
         const execOptions = {}
         execOptions.listeners = {
           stdout: function(data) {
-            core.setOutput('stdout', data.toString());
+            stdout += data.toString()
           },
           stderr: function(data) {
-            core.setOutput('stderr', data.toString());
+            stderr += data.toString()
           }
         }
 
         await exec.exec("ansible-playbook", cmd, execOptions)
+        core.setOutput('stdout', stdout)
+        core.setOutput('stderr', stderr)
     } catch (error) {
         core.setFailed(error.message)
     }

--- a/main.js
+++ b/main.js
@@ -83,10 +83,10 @@ async function main() {
 
         const execOptions = {};
         execOptions.listeners = {
-          stdout: (data: Buffer) => {
+          stdout: function(data) {
             core.setOutput('stdout', data.toString());
           },
-          stderr: (data: Buffer) => {
+          stderr: function(data) {
             core.setOutput('stderr', data.toString());
           }
         };

--- a/main.js
+++ b/main.js
@@ -81,19 +81,18 @@ async function main() {
 
         process.env.ANSIBLE_FORCE_COLOR = "True"
 
-        let output = ''
-        const execOptions = {}
-        execOptions.listeners = {
-          stdout: function(data) {
-            output += data.toString()
-          },
-          stderr: function(data) {
-            output += data.toString()
+        let output = ""
+        await exec.exec(cmd.join(' '), null, {
+          listeners: {
+            stdout: function(data) {
+              output += data.toString()
+            },
+            stderr: function(data) {
+              output += data.toString()
+            }
           }
-        }
-
-        await exec.exec(cmd.join(' '), null, execOptions)
-        core.setOutput('output', output)
+        })
+        core.setOutput("output", output)
     } catch (error) {
         core.setFailed(error.message)
     }

--- a/main.js
+++ b/main.js
@@ -16,7 +16,7 @@ async function main() {
         const options = core.getInput("options")
         const sudo    = core.getInput("sudo")
 
-        let cmd = [playbook]
+        let cmd = ["ansible-playbook", playbook]
 
         if (options) {
             cmd.push(options.replace(/\n/g, " "))
@@ -92,7 +92,7 @@ async function main() {
           }
         }
 
-        await exec.exec("ansible-playbook", cmd, execOptions)
+        await exec.exec(cmd.join(' '), null, execOptions)
         core.setOutput('output', output)
     } catch (error) {
         core.setFailed(error.message)


### PR DESCRIPTION
This pull request captures the output of both stdout and stderr and makes it accessible to the GitHub Actions metadata for use in other Actions. As described in #29, my use case here is to take the results of an ansible-playbook run and post it as a pull request comment. Most of the logic for this pull request was borrowed from the [Actions Toolkit documentation](https://github.com/actions/toolkit/tree/f0b00fd201c7ddf14e1572a10d5fb4577c4bd6a2/packages/exec#outputoptions).

My understanding of Ansible logging is that it will write the output to stdout ([source](https://docs.ansible.com/ansible/latest/reference_appendices/logging.html#logging-ansible-output)), but I thought it might be a good idea to capture stderr as well. I'm happy to remove that option if that's preferable.

Given my unfamiliarity with this Action, I don't have a great sense of how to test this pull request and could use support from someone who is more familiar 🙏.

##

Resolves https://github.com/dawidd6/action-ansible-playbook/issues/29.