### PR TITLE
Add ability to turn off colored output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,9 @@ inputs:
   sudo:
     description: Set to "true" if root is required for running your playbook
     required: false
+  no_color:
+    description: Set to "true" if the Ansible output should not include colors (defaults to "false")
+    required: false
 runs:
   using: node12
   main: main.js

--- a/main.js
+++ b/main.js
@@ -15,7 +15,7 @@ async function main() {
         const knownHosts = core.getInput("known_hosts")
         const options = core.getInput("options")
         const sudo    = core.getInput("sudo")
-        const no_color = core.getInput("no_color")
+        const noColor = core.getInput("no_color")
 
         let cmd = ["ansible-playbook", playbook]
 
@@ -80,7 +80,7 @@ async function main() {
             cmd.unshift("sudo", "-E", "env", `PATH=${process.env.PATH}`)
         }
 
-        if (no_color) {
+        if (noColor) {
             process.env.ANSIBLE_NOCOLOR = "True"
         } else {
             process.env.ANSIBLE_FORCE_COLOR = "True"

--- a/main.js
+++ b/main.js
@@ -15,6 +15,7 @@ async function main() {
         const knownHosts = core.getInput("known_hosts")
         const options = core.getInput("options")
         const sudo    = core.getInput("sudo")
+        const no_color = core.getInput("no_color")
 
         let cmd = ["ansible-playbook", playbook]
 
@@ -79,7 +80,11 @@ async function main() {
             cmd.unshift("sudo", "-E", "env", `PATH=${process.env.PATH}`)
         }
 
-        process.env.ANSIBLE_FORCE_COLOR = "True"
+        if (no_color) {
+            process.env.ANSIBLE_NOCOLOR = "True"
+        } else {
+            process.env.ANSIBLE_FORCE_COLOR = "True"
+        }
 
         await exec.exec(cmd.join(' '))
     } catch (error) {


### PR DESCRIPTION
This pull request adds a new Action input, `no_color`, that when set to `true` will suppress colored Ansible output. This is helpful when capturing the result of the Ansible run without the ANSI color sequences.

##

Resolves #31 