### PR TITLE
Use node16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 jobs:
   remote:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
   pull_request:
-  workflow_dispatch:
 
 jobs:
   remote:

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,6 @@ outputs:
   output:
     description: The captured output of both stdout and stderr from the Ansible Playbook run
 runs:
-  using: node12
+  using: node16
   main: main.js
   post: post.js


### PR DESCRIPTION
Closes #61 

See [GitHub blog post ](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) for details. 

All your tests run fine on this version: https://github.com/clincha/action-ansible-playbook/actions/runs/3253465443

Simple change, implemented fix described here: https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions

Thanks for creating this action @dawidd6 it makes life easier to be able to pass in the private key as a string rather than creating a file.