### PR TITLE
Update know_host example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Should work on any OS, if `ansible-playbook` command is available in `PATH`.
       [group1]
       example.com
     # Optional, SSH known hosts file content
-    known_hosts: .known_hosts
+    known_hosts: |
+      example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
     # Optional, encrypted vault password
     vault_password: ${{secrets.VAULT_PASSWORD}}
     # Optional, galaxy requirements filepath


### PR DESCRIPTION
The documentation suggests that the value of `known_hosts` variable should be a reference to a file, but instead it is the [contents of the file itself](https://github.com/dawidd6/action-ansible-playbook/blob/master/main.js#L70-L74).

Update the documentation to reflect this and make it clear how the known_hosts variable should be used.