### PR TITLE
Add check mode and fixes boolean inputs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: With check mode
+        uses: ./
+        with:
+          playbook: playbook.yml
+          directory: test
+          check: true
+          options: --inventory hosts
       - name: With custom ansible.cfg
         uses: ./
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
             PermitRootLogin no
             Subsystem sftp /usr/lib/openssh/sftp-server
           EOF
-          sudo systemctl restart sshd
+          sudo systemctl restart ssh
           echo 'SSH_KNOWN_HOSTS<<EOF' >> $GITHUB_ENV
           echo $(ssh-keyscan localhost) >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
         with:
           playbook: playbook.yml
           directory: test
-          check: true
+          check_mode: true
           options: --inventory hosts
       - name: With custom ansible.cfg
         uses: ./

--- a/action.yml
+++ b/action.yml
@@ -34,15 +34,15 @@ inputs:
   sudo:
     description: Set to "true" if root is required for running your playbook
     required: false
-    default: "false"
+    default: false
   no_color:
     description: Set to "true" if the Ansible output should not include colors (defaults to "false")
     required: false
-    default: "false"
+    default: false
   check_mode:
     description: Set to "true" to enable check (dry-run) mode
     required: false
-    default: "false"
+    default: false
 outputs:
   output:
     description: The captured output of both stdout and stderr from the Ansible Playbook run

--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,9 @@ inputs:
   no_color:
     description: Set to "true" if the Ansible output should not include colors (defaults to "false")
     required: false
+  check_mode:
+    description: Set to "true" to enable check (dry-run) mode
+    required: false
 outputs:
   output:
     description: The captured output of both stdout and stderr from the Ansible Playbook run

--- a/action.yml
+++ b/action.yml
@@ -34,12 +34,15 @@ inputs:
   sudo:
     description: Set to "true" if root is required for running your playbook
     required: false
+    default: "false"
   no_color:
     description: Set to "true" if the Ansible output should not include colors (defaults to "false")
     required: false
+    default: "false"
   check_mode:
     description: Set to "true" to enable check (dry-run) mode
     required: false
+    default: "false"
 outputs:
   output:
     description: The captured output of both stdout and stderr from the Ansible Playbook run

--- a/main.js
+++ b/main.js
@@ -17,6 +17,7 @@ async function main() {
         const options = core.getInput("options")
         const sudo    = core.getInput("sudo")
         const noColor = core.getInput("no_color")
+        const checkMode = core.getInput("check_mode")
         const fileMode = 0600
 
         let cmd = ["ansible-playbook", playbook]
@@ -92,6 +93,10 @@ async function main() {
             process.env.ANSIBLE_NOCOLOR = "True"
         } else {
             process.env.ANSIBLE_FORCE_COLOR = "True"
+        }
+
+        if (checkMode) {
+            cmd.push("--check")
         }
 
         let output = ""

--- a/main.js
+++ b/main.js
@@ -15,9 +15,9 @@ async function main() {
         const vaultPassword = core.getInput("vault_password")
         const knownHosts = core.getInput("known_hosts")
         const options = core.getInput("options")
-        const sudo    = core.getInput("sudo")
-        const noColor = core.getInput("no_color")
-        const checkMode = core.getInput("check_mode")
+        const sudo    = core.getBooleanInput("sudo")
+        const noColor = core.getBooleanInput("no_color")
+        const checkMode = core.getBooleanInput("check_mode")
         const fileMode = 0600
 
         let cmd = ["ansible-playbook", playbook]


### PR DESCRIPTION
Hi 👋,

First of all thanks for the easy to use Ansible Playbook action. I think it's quite a nifty little workflow gadget to have. However I seem to have stumbled upon a small limitation (for me) and a bug or oversight.

This PR adds a check mode option. Which is IMHO a very [handy feature](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_checkmode.html) in Ansible:

> ### Validating tasks: check mode
> In check mode, Ansible runs without making any changes on remote systems. Modules that support check mode report the changes they would have made. Modules that do not support check mode report nothing and do nothing.

At first this may seem a bit redundant -- because of the `options` input -- but can actually be pretty useful in various (testing) scenarios. For instance when you want to check if a PR is working correctly before merging to the main branch. Having a separate option makes this quite a bit easier to implement 🙂. I have added some examples below.

I've also fixed the boolean inputs, which was required for my change to function correctly 😉 .The value of the boolean inputs actually didn't mean anything. So setting them to `false` would still result in the input being used. Luckily for us a function called `getBooleanInputs()` was [added some time ago](https://github.com/actions/toolkit/issues/361#issuecomment-829507270).

### Example workflows

#### Checking Pull Requests before deployment

This workflow will execute the specified playbook on pushes to the main branch, but will run in check mode when it's triggered from a PR.

```yaml
name: Deploy Docker Playbook

# yamllint disable-line rule:truthy
on:
  push:
    branches:
      - main
  pull_request:

jobs:
  deploy:
    name: Deploy Docker Configuration
    runs-on: ubuntu-latest
    container:
      image: containers/ansible:v2.18.2
    steps:
      - name: ⤵️ Checkout repository
        uses: actions/checkout@v4

      - name: 🚀 Run Ansible Playbook
        uses: dawidd6/action-ansible-playbook@v2
        with:
          playbook: playbooks/docker.yml
          requirements: requirements.yml
          vault_password: ${{ secrets.ANSIBLE_VAULT_KEY }}
          check_mode: ${{ github.event_name == 'pull_request' }}
```

> [!NOTE]
> I use a locally available and prepared container that has Ansible and the necessary dependencies installed. That speeds up playbook execution within workflows quite a bit.

I'm not sure about GitHub, but on Forgejo this can also work wonderfully with branch protections and required checks:

![image](https://github.com/user-attachments/assets/b371cb01-4f95-451d-9bd5-bf3ed5a2c514)

#### Workflow Dispatch

A variant can also be utilized to use Workflow Dispatch inputs to test playbooks on remote.

```yaml
name: Deploy Docker Playbook

# yamllint disable-line rule:truthy
on:
  push:
    branches:
      - main
  workflow_dispatch:
    inputs:
      check_mode:
        description: "Check mode (dry-run)"
        default: false
        required: false
        type: boolean

jobs:
  deploy:
    name: Deploy Docker Configuration
    runs-on: ubuntu-latest
    container:
      image: containers/ansible:v2.18.2
    steps:
      - name: ⤵️ Checkout repository
        uses: actions/checkout@v4

      - name: 🚀 Run Ansible Playbook
        uses: dawidd6/action-ansible-playbook@v2
        with:
          playbook: playbooks/docker.yml
          requirements: requirements.yml
          vault_password: ${{ secrets.ANSIBLE_VAULT_KEY }}
          check_mode: ${{ inputs.check_mode == 'true' }}
```

Which yields a really nice and easy to use check box on my Forgejo instance:

![image](https://github.com/user-attachments/assets/c7e8c1f2-21fe-4db3-95a5-5ac1bb74caaf)

Of course you could also combine both of these scenarios which I have done:

```yaml
  - name: 🚀 Run Ansible Playbook
    uses: dawidd6/action-ansible-playbook@v2
    with:
      playbook: playbooks/docker.yml
      requirements: requirements.yml
      vault_password: ${{ secrets.ANSIBLE_VAULT_KEY }}
      check_mode: >-
        ${{ inputs.check_mode == 'true' ||
            github.event_name == 'pull_request' }}
```

#### Test boolean inputs

To check the boolean inputs -- actually my own change 😇  -- I have used this test workflow:

<details><summary>Test workflow for boolean inputs</summary><p>

```yaml
name: Test

# yamllint disable-line rule:truthy
on:
  push:
    branches:
      - main
  pull_request:
  workflow_dispatch:
    inputs:
      check_mode:
        description: "Check mode (dry-run)"
        default: false
        required: false
        type: boolean

jobs:
  deploy:
    name: Deploy Docker Configuration
    runs-on: docker
    container:
      image: containers/ansible:v2.18.2
    steps:
      - name: ⤵️ Checkout repository
        uses: actions/checkout@v4

      - run: echo ${{ inputs.check_mode }}

      - run: echo ${{ inputs.check_mode == 'true' }}

      - name: 🚀 Run test without check
        uses: ./
        with:
          playbook: test/playbook.yml
          requirements: test/requirements.yml
        continue-on-error: true

      - name: 🚀 Run test with check false
        uses: ./
        with:
          playbook: test/playbook.yml
          requirements: test/requirements.yml
          check_mode: false
        continue-on-error: true

      - name: 🚀 Run test with check
        uses: ./
        with:
          playbook: test/playbook.yml
          requirements: test/requirements.yml
          check_mode: true
        continue-on-error: true

      - name: 🚀 Run test with check string
        uses: ./
        with:
          playbook: test/playbook.yml
          requirements: test/requirements.yml
          check_mode: "true"
        continue-on-error: true
```
</p></details>

Thanks again for the great action. Hopefully you will have a splendid day and can accept this PR 🎂.